### PR TITLE
Don't throw away the entire AST just because of syntax error

### DIFF
--- a/lib/linter.js
+++ b/lib/linter.js
@@ -113,7 +113,7 @@ function parse(text, filename) {
     
     return {
         messages,
-        ast: parseResult && parseResult.errors.length === 0 ? parseResult.ast : null
+        ast: parseResult && parseResult.ast ? parseResult.ast : null
     };
 }
 


### PR DESCRIPTION
Only return a null AST if none exists. This way we can still recover and run rules against the syntax that is valid within the AST.