### PR TITLE
Preface exec jekyll with bundle install

### DIFF
--- a/shell-scripts/run-docs.sh
+++ b/shell-scripts/run-docs.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
 
 cd docs
+bundle install
 bundle exec jekyll serve


### PR DESCRIPTION
Preface the `bundle exec jekyll serve` command with a `bundle install`
to ensure that all required dependencies are installed before we attempt
to use them.