### PR TITLE
Fix config option not working correctly

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -51,14 +51,10 @@ const cli = {
 
         if (currentOptions.init) {
             return handleInitialize(currentOptions);
-
-        } else if (currentOptions.config) {
-            return handleConfiguration(currentOptions.config);
         }
 
         else if (currentOptions.help || !files.length) {
             log.info(options.generateHelp());
-
         } else {
             var hrstart = process.hrtime();
             const engine = new CLIEngine(currentOptions);
@@ -109,7 +105,6 @@ function handleConfiguration(filePath) {
     }
     return setupConfigurationFile(filePath);
 }
-
 
 /**
  * Creates the .wistrc.json file from the contents of the specified file.

--- a/lib/options.js
+++ b/lib/options.js
@@ -16,7 +16,7 @@ module.exports = optionator({
             option: "init",
             alias: "i",
             type: "Boolean",
-            description: "Initialize Wist"
+            description: "Initialize wist with a .wistrc.json"
         },
         {
             option: "config",


### PR DESCRIPTION
Fix for #72 

I'm not sure what the original intention was, but it looks like the -c option copied over a specified config into the current working directory and terminated. This fix changes that behavior to run a lint using the specified config.